### PR TITLE
Add rpc client call HeaderByNumber

### DIFF
--- a/vault.go
+++ b/vault.go
@@ -20,6 +20,7 @@ type VaultClient interface {
 	NextNonce(sender common.Address) (*big.Int, error)
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
+	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 }
 
 func NewVaultClient(chain Blockchain) (*vaultClient, error) {
@@ -114,6 +115,10 @@ func (c vaultClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 
 func (c vaultClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
 	return c.ethClient.BlockByNumber(ctx, number)
+}
+
+func (c vaultClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	return c.ethClient.HeaderByNumber(ctx, number)
 }
 
 func (c vaultClient) getUserOp(sender common.Address, callData []byte) (*UserOperation, error) {


### PR DESCRIPTION
## Summary
Currently, when getting last block on OP mainnet, OP Sepolia and Base, the go-ethereum could not get last blockchain:
`failed to get last block: transaction type not supported`
Same as this issue: https://github.com/ethereum/go-ethereum/issues/26542

If we change to get last header then getting BaseFee from it, the result will be good:
<img width="1302" alt="Screenshot 2024-01-20 at 21 18 41" src="https://github.com/NuKeyHQ/sdk-go/assets/133474846/1cbebc49-c1a1-469b-9b0e-9caa68e3d3d7">
TxHash Sepolia: https://sepolia-optimism.etherscan.io/tx/0xe358ce528b1bf6a6f70aeb459286bd68c5f8b04b2b4164f8129da8ff34ffba13

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Domestic (documentation, non-breaking change that doesn't change code behavior, can skip testing)

## Test Plan:
Local test


## Jira Issues:
N/A